### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/jmcruvellier/little_monkey/security/code-scanning/5](https://github.com/jmcruvellier/little_monkey/security/code-scanning/5)

To fix this issue, we will explicitly define the `permissions` key in the workflow file. Since the workflow primarily involves validation tasks like "Hassfest Validation" and "HACS Validation," these tasks likely only require read access to the repository contents. Therefore, we will set `permissions: contents: read` for the entire workflow. This ensures that the `GITHUB_TOKEN` is limited to the minimal privileges necessary for the tasks.

We will add the `permissions` key at the root level of the workflow (affecting all jobs) to avoid redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
