### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS Action

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/jmcruvellier/little_monkey/security/code-scanning/3](https://github.com/jmcruvellier/little_monkey/security/code-scanning/3)

To fix the issue, a `permissions` block should be added to the workflow. Since the workflow uses the `hacs/action@main` action and interacts with repositories, the `contents` permission (likely limited to `read`) should be explicitly set. If any additional permissions (e.g., `pull-requests: write`) are required for the action to function correctly, they should also be included, but only if necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `hacs` job if different jobs in the workflow have varying permission needs. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
