### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS Action

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   ruff:
+    permissions:
+      contents: read
     name: "Ruff"
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/jmcruvellier/little_monkey/security/code-scanning/2](https://github.com/jmcruvellier/little_monkey/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file to define the minimum required permissions for the job. In this case, the job is primarily reading repository contents and running a linting tool, so it likely only requires `contents: read` permissions.

Specifically:
1. Add a `permissions` block at the job level (under `jobs.ruff`) or at the workflow level (before `jobs:`) if all jobs in the workflow share the same permission requirements.
2. Set `contents: read` to ensure the workflow only has read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
